### PR TITLE
Improve DataPage result when working on a empty collection

### DIFF
--- a/src/Fg.EFCore.QueryExtensions.Tests/DataPagingTests.cs
+++ b/src/Fg.EFCore.QueryExtensions.Tests/DataPagingTests.cs
@@ -84,6 +84,20 @@ namespace Fg.EFCore.QueryExtensions.Tests
             Assert.Equal(2, result.TotalNumberOfItems);
         }
 
+        [Fact]
+        public async Task PagedResultsOnEmptyResultsetDoesNotFail()
+        {
+            var result = await _dbContext.Vessels
+                                         .Where(v => false)
+                                         .ToPagedResultAsync(1, 10);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.PageNumber);
+            Assert.Equal(1, result.TotalPages);
+            Assert.Equal(0, result.TotalNumberOfItems);
+            Assert.Empty(result.Items);
+        }
+
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         public void Dispose()
         {

--- a/src/Fg.EFCore.QueryExtensions/DataPage.cs
+++ b/src/Fg.EFCore.QueryExtensions/DataPage.cs
@@ -20,7 +20,15 @@ namespace Fg.EFCore.QueryExtensions
             TotalNumberOfItems = totalNumberOfItems;
             PageNumber = pageNumber;
             PageSize = pageSize;
-            TotalPages = (int)Math.Ceiling(TotalNumberOfItems / (double)pageSize);
+
+            if (totalNumberOfItems == 0)
+            {
+                TotalPages = 1;
+            }
+            else
+            {
+                TotalPages = (int)Math.Ceiling(TotalNumberOfItems / (double)pageSize);
+            }
         }
     }
 }


### PR DESCRIPTION
When calling `ToPagedResultAsync` on an empty collection, the resulting `DataPage` reported that the returned page was number 1 from a total number of zero pages.  This has been modified so that the total number of pages in this case is also 1, albeit an empty page.